### PR TITLE
docs: improve AI agent instructions

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,86 +1,68 @@
 # Agent guidelines
 
-## Before you start
+This file is the entrypoint for AI agents working in this repository.
 
-- Check `src/_ui/styles/theme.css` for available CSS tokens before touching any color, spacing, typography, or sizing value.
-- If the visual intent is unclear, ask. Don't guess on design decisions.
+## Primary goal
 
-## More info
+Generate structured, presentable pages that match the library standards, use the project assets correctly, and do not break layout, motion, or responsiveness.
 
-- [LP_WORKFLOW.md](./LP_WORKFLOW.md): Workflow for building landing pages.
+## Read order
 
-## Styling hierarchy
+Read only what is needed, in this order:
 
-Always prefer in this order:
+1. `README.md` for the project overview and folder map.
+2. `src/library/pages/template/` for the expected page scaffold.
+3. `src/_ui/styles/theme.css` for shared tokens.
+4. `src/library/components/manifest.json` for component discovery.
+5. The category manifest for the section you are building.
+6. The focused document that matches the task:
+   - `PROJECT_STRUCTURE.md`
+   - `STYLING_RULES.md`
+   - `ASSETS_AND_ICONS.md`
+   - `MOTION_RULES.md`
+   - `LP_WORKFLOW.md`
 
-1. CSS tokens from `src/_ui/styles/theme.css` (e.g. `var(--color-primary)`)
-2. Tailwind default utility classes (e.g. `text-sm`, `gap-4`, `bg-slate-600`)
-3. Arbitrary Tailwind values (e.g. `w-[20rem]`) - only when no token or default fits
-4. Inline styles - as last resort, when none of the above solves the problem.
+Do not scan every manifest, every component file, or every page folder unless the task explicitly requires that breadth.
 
-## Tailwind usage
+## Routing
 
-- Tailwind only, no external CSS frameworks.
-- Avoid utility bloat. Extract repeated class combinations into components.
-- Keep class lists readable: group by concern (layout > spacing > typography > color > state).
-- Use `@apply` sparingly and only when a utility pattern is genuinely reused.
+- Building a landing page: read `LP_WORKFLOW.md` and follow it in order.
+- Choosing where code belongs: read `PROJECT_STRUCTURE.md`.
+- Making styling decisions: read `STYLING_RULES.md`.
+- Choosing or replacing icons and images: read `ASSETS_AND_ICONS.md`.
+- Adding or changing animation: read `MOTION_RULES.md`.
 
-## Component quality
+## Hard rules
 
-- Every component must work in isolation with no assumed context.
-- States matter: empty, loading, error, disabled, hover, focus, active.
-- Never hardcode content, use props/slots. No lorem ipsum left in final output.
-- Maintain visual consistency: spacing rhythm, type scale, and color use should feel intentional.
+- Start from structure, not style. Match section intent and layout before adapting visuals.
+- Reuse `src/library/pages/template/` when creating a new page folder. Do not recreate the scaffold manually.
+- Check `src/_ui/styles/theme.css` before introducing colors, spacing, typography, or breakpoints.
+- Use `src/library/components/manifest.json` before opening raw component HTML.
+- Open only the category manifest that matches the current section. Do not browse unrelated categories.
+- Copy component markup into the page and adapt it there. Do not create runtime dependencies between library demo files and page files.
+- Use GSAP only when the motion is meaningful. Respect `prefers-reduced-motion`.
+- Keep placeholder content obvious in the handoff. Never present placeholder copy or media as final brand content.
 
-## Animation & transitions
+## When to stop and ask
 
-- Use GSAP for advanced animations and transitions.
-- Use CSS `transition`/`animation` for simple hover effects.
-- Animate with purpose - motion should guide attention, not decorate.
-- Respect `prefers-reduced-motion`. Wrap GSAP calls accordingly.
-- Keep animations short (150–400ms typical). Avoid animating layout properties (prefer `transform`/`opacity`).
+Ask only if one of these blocks progress:
 
-## Icons & images
+- The brief is too thin to determine page sections or content hierarchy.
+- The task changes a public pattern and multiple valid directions would affect the library standard.
+- Brand direction is required and cannot be inferred from the provided context.
 
-- SVG only for icons, inline or as components. Never use emojis as UI elements.
-- Use FontAwesome as a placeholder if the final icon isn't defined yet.
-- Image placeholders: Unsplash, Picsum, or placeholder.co. Match aspect ratio and context.
-- Always set `alt` text. Decorative images get `alt=""`.
+## Anti-patterns
 
-## Responsive design
+- Do not pick components by visual style alone.
+- Do not scan all manifests hoping for inspiration.
+- Do not leave invisible content, broken anchors, or missing sections.
+- Do not hardcode decorative emojis, random icon sets, or untracked external assets.
+- Do not use inline styles when tokens or utilities already solve the need.
 
-- Mobile-first. Build the small breakpoint first, then scale up.
-- Use Tailwind breakpoints (`sm`, `md`, `lg`, `xl`).
-- Touch targets: minimum 44×44px. No hover-only interactions on mobile.
+## Done criteria
 
-## Accessibility
-
-- Semantic HTML always. Don't use `div` where a `button`, `nav`, or `section` applies.
-- Keyboard navigation must work for all interactive elements.
-- Sufficient color contrast (WCAG AA minimum). Never convey info by color alone.
-- ARIA only when native semantics fall short. Wrong ARIA is worse than none.
-- Focus styles must be visible, don't suppress `:focus-visible`.
-
-## Performance
-
-- No layout thrash. Batch DOM reads and writes, don't interleave them.
-- Lazy-load images below the fold (`loading="lazy"`).
-- Avoid animating properties that trigger reflow (`width`, `height`, `top`, `left`).
-- Keep component render logic lean, no heavy computation in render paths.
-
-## SEO & best practices
-
-- One `h1` per page. Heading hierarchy must be logical and unbroken.
-- Meaningful `title` and `meta description` on page-level work.
-- Avoid `display:none` to hide content that should be indexed.
-- Prefer `<a>` for navigation, `<button>` for actions, never swap them.
-
-## Self-review checklist
-
-- [ ] Styling follows the token > Tailwind > arbitrary hierarchy
-- [ ] All interactive states are handled
-- [ ] Component works on mobile and desktop
-- [ ] Animations respect `prefers-reduced-motion`
-- [ ] No emojis, hardcoded content, or placeholder text left in
-- [ ] Semantic HTML and keyboard navigation verified
-- [ ] No unused classes or dead markup
+- The page is responsive.
+- No required section is missing.
+- No element is unintentionally invisible.
+- Motion and transitions are smooth and purposeful.
+- Code stays readable and aligned with repository conventions.

--- a/.agents/ASSETS_AND_ICONS.md
+++ b/.agents/ASSETS_AND_ICONS.md
@@ -1,0 +1,35 @@
+# Assets and icons rules
+
+Use this document when choosing images, illustrations, logos, or icons.
+
+## Asset locations
+
+- Store project-owned static assets in `src/_public/`.
+- Reuse existing assets from `src/_public/assets/` whenever they fit the brief.
+- Keep page markup pointing at stable asset paths that will exist in production.
+
+## Images
+
+- Prefer existing repository assets before adding new placeholders.
+- If placeholders are necessary, use sources already allowed by the project guidance: Unsplash, Picsum, or placeholder.co.
+- Match the content and aspect ratio to the section intent.
+- Every image must have `alt` text. Decorative images must use `alt=""`.
+- Add `loading="lazy"` for below-the-fold images.
+
+## Icons
+
+- Use SVG icons only.
+- Prefer existing icons from `src/_public/assets/icons/` when suitable.
+- If the final icon set is not defined yet, use FontAwesome only as a temporary placeholder.
+- Do not use emojis as UI icons.
+
+## Brand assets
+
+- Treat logos, product screenshots, and branded illustrations as replaceable unless the brief confirms they are final.
+- If you use placeholders for brand assets, call them out clearly in the handoff.
+
+## Avoid
+
+- Hotlinking production assets from random third-party sites.
+- Mixing unrelated icon styles on the same page.
+- Using decorative media that weakens readability or obscures content.

--- a/.agents/LP_WORKFLOW.md
+++ b/.agents/LP_WORKFLOW.md
@@ -1,74 +1,123 @@
-# Landing Page Workflow
+# Landing page workflow
 
-Follow this workflow exactly, in order. No skipping, merging, reordering, or ad-hoc steps.
+Follow this workflow in order. Do not skip steps or scan broadly without a reason.
 
-## 1. Documentation
+## 1. Read the minimum required context
 
-Check for an existing PRD or brief (`.md`, `.txt`, or similar) in the project or provided context. If none exists, create `PRD.md` inside the page folder (see next step) with this structure:
+Read only these inputs first:
+
+1. The user prompt or brief
+2. `README.md`
+3. `src/library/pages/template/`
+4. `src/_ui/styles/theme.css`
+5. `src/library/components/manifest.json`
+
+Only open additional files when a step below requires them.
+
+## 2. Confirm the brief
+
+- Look for an existing brief or PRD in the provided context or target page folder.
+- If none exists, create `PRD.md` inside the page folder.
+- Use the PRD as the source of truth for section order, content intent, open placeholders, and completion tracking.
+- If the brief is too thin to determine the section list or core message, stop and ask.
+
+Recommended PRD shape:
 
 ```markdown
 # [Page Name] - PRD
 
 ## Company details
 
-- Name, industry, tone/voice, brand colors, target audience, key differentiators, .
+- Name:
+- Industry:
+- Tone:
+- Brand colors:
+- Target audience:
+- Key differentiators:
 
 ## Page skeleton
 
-Ordered list of sections with intent. Example:
-
-1. Header - sticky nav with logo and CTA
-2. Hero - headline, subheadline, primary CTA, background image
-3. Features - 3-column grid
-   ...
+1. Header - intent
+2. Hero - intent
+3. Feature section - intent
 
 ## Implementation plan
 
-- [ ] Section 1
-- [ ] Section 2
-      ...
+- [ ] Header
+- [ ] Hero
+- [ ] Feature section
+
+## Placeholders and assumptions
+
+- Placeholder screenshots:
+- Missing brand assets:
+- Open content assumptions:
 ```
 
-If a PRD already exists, read it fully before proceeding. Don't assume, if the brief is too thin to build from, ask before starting.
+## 3. Set up the page correctly
 
-## 2. Project setup
+- Target location: `src/library/pages/[page-name]/` unless the task says otherwise.
+- If the folder does not exist, copy `src/library/pages/template/`.
+- Do not rebuild the page scaffold by hand.
+- Update metadata first: `title`, `meta description`, and any obvious template placeholders.
 
-Page folder location: `src/library/pages/[company-name]/` (unless told otherwise).
+## 4. Build sections one by one
 
-If the folder doesn't exist, copy `src/library/pages/template/` to `src/library/pages/[company-name]/`. Don't create the files manually, the template already includes the correct HTML wrapper, CSS token imports, and JS setup. Only update surface-level metadata: `<title>`, `<meta name="description">`, and any placeholder comments.
+Work in the same order as the PRD. For each section, use this decision path:
 
-## 3. Section implementation
+1. Match the section intent against `src/library/components/manifest.json` category descriptions and tags.
+2. Open only the best matching category manifest.
+3. Rank variants by structure first: layout, information hierarchy, and interaction pattern.
+4. Use the variant `location` to jump directly to the block in that category `index.html`.
+5. Copy the chosen block into the page and adapt it.
+6. If no component is a good fit, build the section from scratch.
 
-Work through the page skeleton one section at a time, in order. For each section, do the following steps:
+## 5. Manifest-first rules
 
-- **Search first (manifest-driven).** Use `src/library/components/manifest.json` before opening raw HTML.
-  1. Match the section intent (from `PRD.md`) against root manifest `categories[].description` and `categories[].tags`.
-  2. Open the best category manifest at `src/library/components/[category]/manifest.json`.
-  3. Rank variants by `description` and `tags` (layout, interaction, style, use-case).
-  4. Use `location` to jump directly to the right block in `src/library/components/[category]/index.html`.
-  5. Only if the manifest is insufficient, scan the category `index.html` manually.
-- **Selection rule.** Prefer the closest structural match first (layout and interaction), then adapt visuals/content. Do not pick by style alone.
-- **If a match exists:** Copy the component HTML into `index.html` and adapt it. Update content, classes, and structure to fit the page. Don't reference or import, copy directly.
-- **If no match exists:** Build the section from scratch, following the UI/UX guidelines.
-- Mark each section as complete in `PRD.md` as you go.
+- Never start by scanning raw `index.html` files across multiple categories.
+- Never open every category manifest for a single section.
+- Never choose a component only because it looks close visually.
+- Choose the closest structural match, then adapt style, copy, media, and details.
+- If the manifest is insufficient, open only the category file already selected for that section.
 
-**IMPORTANT:** If you have support for subagents, delegate each section to a subagent to prevent context rot. Each subagent should receive: the PRD, `src/library/components/manifest.json`, the chosen category manifest, the relevant component HTML block (if found), the page's current `index.html`, and the token file at `src/_ui/styles/theme.css`.
+## 6. Styling and asset rules during implementation
 
-## 4. Finishing touches
+- Follow `STYLING_RULES.md` for all visual decisions.
+- Follow `ASSETS_AND_ICONS.md` for images, icons, and placeholders.
+- Keep page-specific styling in the page folder unless a shared pattern is clearly being created.
+- Keep placeholder assets and copy obvious and track them in the PRD or handoff.
 
-Once all sections are in place:
+## 7. Motion and interactivity
 
-- **Animations:** Add GSAP scroll-triggered entrance animations for key sections (heroes, features, stats, CTAs). Keep them subtle and purposeful. Respect `prefers-reduced-motion`.
-- **Transitions:** Add hover/focus transitions for interactive elements if not already handled by component styles.
-- **Optimization:** Ensure all images have `alt` text, lazy-loading is set for below-fold images, heading hierarchy is valid, and there are no unused classes or dead markup.
-- **Final check:** Run through the UI/UX self-review checklist.
+- Follow `MOTION_RULES.md`.
+- Add GSAP entrances only for key sections when they improve hierarchy.
+- Respect `prefers-reduced-motion`.
+- Verify anchors, hover states, focus states, and scroll behavior after motion changes.
 
-## 5. Handoff
+## 8. Prevent context rot
 
-Keep the report short. Note only:
+- Stay scoped to the current section.
+- Do not reopen unrelated files once a valid component path is chosen.
+- If subagents are available, delegate by section so each one receives only the PRD, token file, relevant manifests, chosen component block, and current page files.
+- Return to the PRD after each section and mark progress immediately.
 
-- Any **placeholder content** that needs replacing (images, copy, links, brand assets).
-- Any **design decisions** made where the brief was ambiguous.
-- Any **missing tokens** that caused a fallback to Tailwind defaults or arbitrary values.
+## 9. Final validation
 
-The `PRD.md` is the source of truth, it should reflect what was built.
+Before handoff, verify all of the following:
+
+- The page is responsive on mobile and desktop.
+- No required section is missing.
+- No element is invisible because of color, overflow, positioning, or animation state.
+- Transitions and animations feel smooth and do not block interaction.
+- Heading hierarchy, links, alt text, and keyboard access are valid.
+- Code is readable and consistent with the rest of the library.
+- No dead markup, unused selectors, or obvious placeholders were left undocumented.
+
+## 10. Handoff format
+
+Keep the final report short and include only:
+
+- Placeholder content that still needs replacement
+- Design decisions made because the brief was ambiguous
+- Missing tokens that forced Tailwind defaults or arbitrary values
+- Any section built from scratch because the library had no structural match

--- a/.agents/MOTION_RULES.md
+++ b/.agents/MOTION_RULES.md
@@ -1,0 +1,34 @@
+# Motion rules
+
+Use this document when adding animation, scroll behavior, or transitions.
+
+## Motion intent
+
+- Motion must guide attention, reinforce hierarchy, or improve perceived continuity.
+- Prefer no animation over decorative animation with no job.
+
+## Tool choice
+
+- Use GSAP for advanced or scroll-linked motion.
+- Use CSS transitions or keyframes for simple hover and focus states.
+- Prefer `transform` and `opacity` over layout-triggering properties.
+
+## Safety rules
+
+- Respect `prefers-reduced-motion` for all non-essential animation.
+- Keep timings short and readable. Typical range: 150ms to 400ms for simple transitions.
+- Avoid long chained timelines unless they materially improve the experience.
+- Do not create motion that blocks reading, interaction, or scrolling.
+
+## Landing page defaults
+
+- Animate entrances for hero, features, stats, and CTA only when it improves scanability.
+- Use stagger and scroll-trigger effects lightly.
+- Keep hover and focus transitions subtle and consistent.
+- Verify that animated elements are still visible and correctly positioned before and after animation.
+
+## Avoid
+
+- Animating `width`, `height`, `top`, or `left` when a transform works.
+- Scroll effects that cause flicker, overlap, or content jumps.
+- Smooth-scroll behavior that breaks anchors or keyboard navigation.

--- a/.agents/PROJECT_STRUCTURE.md
+++ b/.agents/PROJECT_STRUCTURE.md
@@ -1,0 +1,44 @@
+# Project structure rules
+
+Use this document when deciding where files, markup, styles, and scripts belong.
+
+## Source of truth
+
+- `src/library/pages/` contains page implementations and page templates.
+- `src/library/components/` contains reusable demo blocks and manifests for discovery.
+- `src/_ui/styles/` contains shared global styles and tokens.
+- `src/_ui/components/` and `src/_ui/scripts/` contain shared UI primitives and logic.
+- `src/_public/` contains static assets copied directly to the build output.
+
+## New landing pages
+
+- Create new landing pages in `src/library/pages/[page-name]/`.
+- Start by copying `src/library/pages/template/`.
+- Preserve the wrapper structure, asset loading pattern, and script entrypoints from the template.
+- Only change page metadata immediately: title, description, and content inside `#smooth-content`.
+
+## Component adaptation
+
+- Treat files in `src/library/components/` as source material, not importable runtime dependencies.
+- Use manifests to find the closest structural match.
+- Copy the chosen HTML block into the target page and adapt it there.
+- If the existing component is almost right, adapt the copied markup instead of editing the component library unless the task is explicitly about improving the library itself.
+
+## Style placement
+
+- Shared tokens belong in `src/_ui/styles/theme.css`.
+- Shared global styles belong in `src/_ui/styles/`.
+- Page-specific styles belong in that page folder, usually `src/library/pages/[page-name]/index.css`.
+- Do not move one-off page styling into global files unless at least two places need it.
+
+## Script placement
+
+- Page-specific animation or interactions belong in the page `index.js`.
+- Shared interaction logic belongs in `src/_ui/scripts/` only when it is reused or clearly generic.
+- Do not add new shared abstractions for a single page need.
+
+## File hygiene
+
+- Keep each page self-contained: `index.html`, `index.css`, `index.js`, and optional `PRD.md`.
+- Keep placeholder decisions documented in the page handoff or `PRD.md`.
+- Remove dead markup, unused selectors, and unused animation hooks before finishing.

--- a/.agents/STYLING_RULES.md
+++ b/.agents/STYLING_RULES.md
@@ -1,0 +1,46 @@
+# Styling rules
+
+Use this document when making visual and CSS decisions.
+
+## Priority order
+
+Always prefer styling in this order:
+
+1. Tokens from `src/_ui/styles/theme.css`
+2. Tailwind default utilities
+3. Tailwind arbitrary values when no token or default utility fits
+4. Inline styles only as a last resort
+
+## Tokens first
+
+- Check `src/_ui/styles/theme.css` before introducing colors, text colors, borders, backgrounds, or breakpoints.
+- Reuse the existing semantic tokens whenever possible.
+- If a needed value is missing, note the fallback in the handoff instead of inventing many one-off arbitrary values.
+
+## Global vs local styling
+
+- Put reusable visual primitives in shared styles only when they are clearly generic.
+- Keep page art direction, one-off layouts, and unique section treatments local to the page.
+- Do not pollute global styles with page-specific selectors.
+
+## Tailwind usage
+
+- Use Tailwind only. Do not introduce another CSS framework.
+- Keep class lists readable and ordered by concern: layout, spacing, typography, color, state.
+- Use `@apply` sparingly and only for genuinely repeated patterns.
+- Avoid utility bloat. If a class combination repeats several times inside one page, extract a local class.
+
+## Quality rules
+
+- Mobile-first always.
+- Use the project breakpoints already available in tokens and Tailwind.
+- Keep spacing rhythm consistent across sections.
+- Preserve a clear heading hierarchy with one `h1` per page.
+- Ensure interactive states are visible and usable on touch and keyboard.
+
+## Avoid
+
+- Random hardcoded hex colors when tokens already cover the need.
+- Large volumes of arbitrary spacing values without a clear reason.
+- Hidden overflow or absolute positioning that causes clipped or invisible content on small screens.
+- Placeholder text left in the final result.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ This layout keeps runnable code in src/ and configuration at the root.
 - Fast prototyping with Tailwind utilities.
 - Projects where small bundle size and quick iteration matter.
 
+## Working with AI agents
+
+AI agents should start from `.agents/AGENTS.md`, which routes them to the focused guidance for landing-page workflows, project structure, styling, assets, and motion.
+
+Recommended prompt inputs for the best result:
+
+- Company or product name
+- Industry and audience
+- Tone and visual direction
+- Required page sections and priorities
+- Brand colors, logos, screenshots, and icon preferences
+- Any content that must stay final versus placeholder
+
+Agent workflow expectations:
+
+- Reuse `src/library/pages/template/` for new pages
+- Check `src/_ui/styles/theme.css` before introducing new values
+- Use `src/library/components/manifest.json` before opening component HTML
+- Choose components by structural fit first, then adapt visuals
+- Report placeholders, assumptions, and token gaps in the handoff
+
 ## License
 
 The code is available under the [MIT license](LICENSE).


### PR DESCRIPTION
## Summary
- turn `.agents/AGENTS.md` into a stricter routing entrypoint with read order, hard rules, and anti-patterns
- add focused agent docs for project structure, styling, assets, and motion so landing-page tasks can stay scoped
- refine the landing-page workflow and README guidance to make manifest-first discovery explicit and reduce context rot

## Testing
- not run (documentation-only changes)

Closes #4